### PR TITLE
Allow for poToken and VisitorData generation for Clients on Youtube Object

### DIFF
--- a/src/main/java/com/github/felipeucelli/javatube/InnerTube.java
+++ b/src/main/java/com/github/felipeucelli/javatube/InnerTube.java
@@ -662,6 +662,8 @@ public class InnerTube{
     }
 
     public void insetPoToken(String poToken, String visitorData) throws JSONException {
+        this.accessPoToken = poToken;
+        this.accessVisitorData = visitorData;
         JSONObject context = new JSONObject(
                 "{" +
                             "\"context\": {" +

--- a/src/main/java/com/github/felipeucelli/javatube/Youtube.java
+++ b/src/main/java/com/github/felipeucelli/javatube/Youtube.java
@@ -107,10 +107,19 @@ public class Youtube {
         this.usePoToken = usePoToken;
         this.allowCache = allowCache;
         if (this.usePoToken) {
-            String token = BotGuard.generatePoToken(getVideoId());
-            String vData = getVisitorData();
-            innerTube.insetPoToken(token, vData);
+            String poToken = BotGuard.generatePoToken(getVideoId());
+            String visitorData = getVisitorData();
+            if (isValidToken(poToken) && isValidVisitorData(visitorData)) {
+                innerTube.insetPoToken(poToken, visitorData);
+            }
         }
+    }
+
+    private boolean isValidToken(String poToken) {
+        return poToken != null && !poToken.isBlank();
+    }
+    private boolean isValidVisitorData(String visitorData) {
+        return visitorData != null && !visitorData.isBlank();
     }
 
     private String setVideoId() throws RegexMatchError {

--- a/src/main/java/com/github/felipeucelli/javatube/Youtube.java
+++ b/src/main/java/com/github/felipeucelli/javatube/Youtube.java
@@ -101,11 +101,16 @@ public class Youtube {
      * */
     public Youtube(String url, String clientName, boolean usePoToken, boolean allowCache) throws Exception {
         client = usePoToken ? "WEB" : clientName;
-        this.usePoToken = usePoToken;
-        this.allowCache = allowCache;
-        innerTube = new InnerTube(client, usePoToken, allowCache);
+        this.innerTube = new InnerTube(client, usePoToken, allowCache);
         urlVideo = url;
         watchUrl = "https://www.youtube.com/watch?v=" + getVideoId();
+        this.usePoToken = usePoToken;
+        this.allowCache = allowCache;
+        if (this.usePoToken) {
+            String token = BotGuard.generatePoToken(getVideoId());
+            String vData = getVisitorData();
+            innerTube.insetPoToken(token, vData);
+        }
     }
 
     private String setVideoId() throws RegexMatchError {


### PR DESCRIPTION
Previously when creating Youtube Object with usePoToken=true it would only work via supplying visitor data and potoken manually from defaultPoTokenVerifier(). Now it resolves it if possible.